### PR TITLE
Basic throughput TCP server and client

### DIFF
--- a/throughput/Cargo.toml
+++ b/throughput/Cargo.toml
@@ -14,4 +14,6 @@ tokio-util =  { version = "0.7.4", features = ["full"] }
 serde = { version = "1.0.151", features = ["derive"]}
 serde_bytes = "0.11.8"
 futures-util = "0.3.25"
+futures = "0.3.25"
 bincode = "1.3.3"
+bytes = "1.3.0"

--- a/throughput/Cargo.toml
+++ b/throughput/Cargo.toml
@@ -13,3 +13,5 @@ anyhow = "1.0.68"
 tokio-util =  { version = "0.7.4", features = ["full"] }
 serde = { version = "1.0.151", features = ["derive"]}
 serde_bytes = "0.11.8"
+futures-util = "0.3.25"
+bincode = "1.3.3"

--- a/throughput/Cargo.toml
+++ b/throughput/Cargo.toml
@@ -9,4 +9,7 @@ edition = "2021"
 common = { path = "../common" }
 clap = { version = "4.0.30", features = ['derive'] }
 tokio = { version = "1.23.0", features = ['full'] }
-anyhow = {}
+anyhow = "1.0.68"
+tokio-util =  { version = "0.7.4", features = ["full"] }
+serde = { version = "1.0.151", features = ["derive"]}
+serde_bytes = "0.11.8"

--- a/throughput/src/args.rs
+++ b/throughput/src/args.rs
@@ -78,7 +78,7 @@ pub enum ClientProtocol {
 #[derive(Args, Clone, Debug)]
 pub struct TcpClientOpts {
     #[command(flatten)]
-    client_common_opts: ClientCommonOpts,
+    pub client_common_opts: ClientCommonOpts,
 }
 
 #[derive(Args, Clone, Debug)]
@@ -90,7 +90,7 @@ pub struct UdpClientOpts {
 #[derive(Args, Clone, Debug)]
 pub struct QuicClientOpts {
     #[command(flatten)]
-    client_common_opts: ClientCommonOpts,
+    pub client_common_opts: ClientCommonOpts,
 }
 
 #[derive(Args, Clone, Debug)]
@@ -112,13 +112,22 @@ pub struct ServerCommonOpts {
 pub struct ClientCommonOpts {
     /// IP of the server
     #[arg(short = 'c', long = "client")]
-    server_ip: Option<IpAddr>,
+    pub server_ip: IpAddr,
 
     /// Port of the server
-    #[arg(short, long)]
-    port: Option<u16>,
+    #[arg(short = 'p', long)]
+    pub server_port: u16,
 
     /// Interface to bind to
     #[arg(short, long)]
-    interface: Option<String>,
+    pub interface: Option<String>,
+
+    /// Clients own interface on which to bind
+    #[arg(long = "cip")]
+    pub client_ip: IpAddr,
+
+    /// Port the client will bind to locally.
+    /// Leave empty to use an ephemeral port
+    #[arg(long = "cport")]
+    pub client_port: Option<u16>,
 }

--- a/throughput/src/main.rs
+++ b/throughput/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 
 mod args;
 mod tcpserver;
+mod tcpclient;
 mod messages;
 
 #[tokio::main]
@@ -25,8 +26,18 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
         },
-        Some(args::Modes::Client { proto: _ }) => {
-            todo!()
+        Some(args::Modes::Client { proto }) => {
+            match proto {
+                args::ClientProtocol::Tcp(options) => {
+                    tcpclient::run(options).await
+                },
+                args::ClientProtocol::Udp(..) => {
+                    todo!()
+                },
+                args::ClientProtocol::Quic(..) => {
+                    todo!()
+                }
+            }
         },
         None => { Ok({}) }
     };

--- a/throughput/src/main.rs
+++ b/throughput/src/main.rs
@@ -1,4 +1,3 @@
-use std::io;
 use clap::Parser;
 
 mod args;
@@ -15,6 +14,7 @@ async fn main() -> anyhow::Result<()> {
         Some(args::Modes::Server { proto }) => {
             match proto {
                 args::ServerProtocol::Tcp(options) => {
+                    println!("Starting tcp server");
                     tcpserver::run(options).await
                 },
                 args::ServerProtocol::Udp(..) => {

--- a/throughput/src/main.rs
+++ b/throughput/src/main.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 
 mod args;
 mod tcpserver;
+mod messages;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/throughput/src/messages.rs
+++ b/throughput/src/messages.rs
@@ -1,0 +1,46 @@
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
+use anyhow::Result;
+
+
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct Packet {
+    packet_type: PacketType,
+    connection_id: u16
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub enum PacketType {
+    SideChannel(SideChannel),
+    Throughput(Throughput)
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct SideChannel {
+
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub enum SideChannelMessageTypes {
+    MeasurementReport(MeasurementReport),
+    MeasurementStatus(MeasurementStatus)
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct MeasurementReport {
+
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct MeasurementStatus {
+
+}
+
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct Throughput {
+    #[serde(with = "serde_bytes")]
+    pub payload: Vec<u8>
+}

--- a/throughput/src/messages.rs
+++ b/throughput/src/messages.rs
@@ -1,12 +1,6 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-pub struct Packet {
-    pub packet_type: PacketType,
-    pub connection_id: u16
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub enum PacketType {
     SideChannel(SideChannel),
     Throughput(Throughput)
@@ -14,7 +8,7 @@ pub enum PacketType {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct SideChannel {
-
+    pub connection_id: u16
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
@@ -36,6 +30,7 @@ pub struct MeasurementStatus {
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct Throughput {
+    pub connection_id: u16,
     #[serde(with = "serde_bytes")]
     pub payload: Vec<u8>
 }

--- a/throughput/src/messages.rs
+++ b/throughput/src/messages.rs
@@ -1,14 +1,9 @@
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncRead, AsyncWrite};
-use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
-use anyhow::Result;
-
-
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct Packet {
-    packet_type: PacketType,
-    connection_id: u16
+    pub packet_type: PacketType,
+    pub connection_id: u16
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]

--- a/throughput/src/tcpclient.rs
+++ b/throughput/src/tcpclient.rs
@@ -1,0 +1,44 @@
+use std::net::SocketAddr;
+use anyhow::{Result, Error};
+use tokio::net::TcpStream;
+use common::new_tcp_socket;
+use crate::args::TcpClientOpts;
+use crate::messages::{PacketType, Throughput};
+use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
+use futures::sink::SinkExt;
+use crate::messages;
+
+pub async fn run(options: TcpClientOpts) -> Result<()> {
+    let socket = new_tcp_socket(
+        options.client_common_opts.interface,
+        options.client_common_opts.client_ip,
+        options.client_common_opts.client_port
+    )?;
+
+    let server_address = SocketAddr::new(
+        options.client_common_opts.server_ip,
+        options.client_common_opts.server_port);
+    socket.set_nonblocking(false)?;
+    socket.connect(&server_address.into())?;
+    let mut client = TcpStream::from_std(socket.into())?;
+
+    let (reader, writer) = client.split();
+
+    let _f_reader = FramedRead::new(reader, LengthDelimitedCodec::new());
+    let mut f_writer = FramedWrite::new(writer, LengthDelimitedCodec::new());
+
+
+    let tp_packet = PacketType::Throughput(
+        Throughput {
+            connection_id: 0,
+            payload: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
+    );
+
+    let encoded = bincode::serialize(&tp_packet)?;
+
+    f_writer.send(bytes::Bytes::from(encoded)).await?;
+    //client.write_all(&encoded).await?;
+
+    Ok(())
+}

--- a/throughput/src/tcpclient.rs
+++ b/throughput/src/tcpclient.rs
@@ -20,6 +20,7 @@ pub async fn run(options: TcpClientOpts) -> Result<()> {
         options.client_common_opts.server_port);
     socket.set_nonblocking(false)?;
     socket.connect(&server_address.into())?;
+    socket.set_nonblocking(true)?;
     let mut client = TcpStream::from_std(socket.into())?;
 
     let (reader, writer) = client.split();

--- a/throughput/src/tcpserver.rs
+++ b/throughput/src/tcpserver.rs
@@ -1,8 +1,9 @@
 use tokio::io;
-use tokio::net::TcpListener;
+use tokio::net::{TcpListener, TcpStream};
 use common::new_tcp_socket;
 use crate::args::TcpServerOpts;
 use anyhow::Result;
+use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
 
 
 pub async fn run(options: TcpServerOpts) -> Result<()> {
@@ -15,9 +16,22 @@ pub async fn run(options: TcpServerOpts) -> Result<()> {
     let listener = TcpListener::from_std(socket.into())?;
 
     loop {
-        let (socket, _client_address) = listener.accept().await?;
+        let (stream, _client_address) = listener.accept().await?;
     }
 
 
     Ok(())
+}
+
+async fn handle_stream(mut stream: TcpStream) -> Result<()> {
+    let (reader, writer) = stream.split();
+
+    let f_reader = FramedRead::new(reader, LengthDelimitedCodec::new());
+    let f_writer = FramedWrite::new(writer, LengthDelimitedCodec::new());
+
+    loop {
+
+    }
+    
+    todo!()
 }

--- a/throughput/src/tcpserver.rs
+++ b/throughput/src/tcpserver.rs
@@ -1,10 +1,11 @@
-use tokio::io;
 use tokio::net::{TcpListener, TcpStream};
 use common::new_tcp_socket;
 use crate::args::TcpServerOpts;
-use anyhow::Result;
+use anyhow::{Result, Error};
 use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
 
+use futures_util::StreamExt;
+use crate::messages;
 
 pub async fn run(options: TcpServerOpts) -> Result<()> {
     let socket = new_tcp_socket(
@@ -13,25 +14,46 @@ pub async fn run(options: TcpServerOpts) -> Result<()> {
         options.server_common_opts.port
     )?;
 
+    socket.listen(128)?;
     let listener = TcpListener::from_std(socket.into())?;
 
+    println!("Entering run loop");
     loop {
         let (stream, _client_address) = listener.accept().await?;
+        println!("Handling connection");
+        handle_stream(stream).await?
     }
 
-
-    Ok(())
 }
 
 async fn handle_stream(mut stream: TcpStream) -> Result<()> {
     let (reader, writer) = stream.split();
 
-    let f_reader = FramedRead::new(reader, LengthDelimitedCodec::new());
-    let f_writer = FramedWrite::new(writer, LengthDelimitedCodec::new());
+    let mut f_reader = FramedRead::new(reader, LengthDelimitedCodec::new());
+    let _f_writer = FramedWrite::new(writer, LengthDelimitedCodec::new());
 
     loop {
+        if let Some(received) = f_reader.next().await {
+            match received {
+                Ok(received) => {
+                    let decoded: messages::Packet = bincode::deserialize(&received)?;
 
+                    match decoded.packet_type {
+                        messages::PacketType::SideChannel(_sch) => {
+                            todo!()
+                        },
+                        messages::PacketType::Throughput(tp) => {
+                            println!("Got TP packet, conn_id: {}, payload_size: {} bytes",
+                                     decoded.connection_id, tp.payload.len())
+                        }
+
+                    }
+                },
+                Err(e) => {
+                    return Err(Error::from(e))
+                }
+            }
+
+        }
     }
-    
-    todo!()
 }


### PR DESCRIPTION
This series adds the basic functionality of creating TCP sockets and from that, create TCP listeners and clients respectively.

Also included in this series are some basic messaging attempts as examples of what the throughput client and server will sending between each other.

Finally, there is some additional work beging done on the CLI for throughput.