### PR TITLE
Ping client: Handle when user presses ctrl+c

### DIFF
--- a/ping/src/icmp.rs
+++ b/ping/src/icmp.rs
@@ -9,6 +9,7 @@ use common::{interface_to_ipaddr, AsyncICMPSocket, ICMPSocket, Statistics};
 use etherparse::{
     IcmpEchoHeader, Icmpv4Header, Icmpv4Type,
 };
+use tokio::signal;
 
 
 use crate::{
@@ -186,6 +187,11 @@ impl ICMPClient {
 
 
 
+                },
+                _= signal::ctrl_c() => {
+                    // Print on a new line, because some terminals will print "^C" in which makes the text look ugly
+                    println!("\nCtrl-C received, exiting");
+                    break
                 }
 
             }

--- a/ping/src/tcp.rs
+++ b/ping/src/tcp.rs
@@ -10,6 +10,7 @@ use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use tokio::{
     net::{TcpListener as TokioTcpListener, TcpStream as TokioTcpStream},
+    signal
 };
 use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
 
@@ -158,6 +159,11 @@ impl TCPClient {
                     else {
                         println!("{} bytes from {}: tcp_pay_seq={} time={:.3} ms", frame.len(), result.src_addr, result.seq, result.rtt);
                     }
+                },
+                _= signal::ctrl_c() => {
+                    // Print on a new line, because some terminals will print "^C" in which makes the text look ugly
+                    println!("\nCtrl-C received, exiting");
+                    break
                 }
             }
         }

--- a/ping/src/udp.rs
+++ b/ping/src/udp.rs
@@ -7,7 +7,7 @@ use std::{
 use anyhow::{anyhow, Result};
 use common::{interface_to_ipaddr, Statistics, UDPSocket};
 use serde::{Deserialize, Serialize};
-use tokio::net::UdpSocket as tokioUdpSocket;
+use tokio::{net::UdpSocket as tokioUdpSocket, signal};
 
 use crate::{
     args,
@@ -151,6 +151,11 @@ impl UDPClient {
 
 
 
+                },
+                _= signal::ctrl_c() => {
+                    // Print on a new line, because some terminals will print "^C" in which makes the text look ugly
+                    println!("\nCtrl-C received, exiting");
+                    break
                 }
 
             }


### PR DESCRIPTION
When the user presses ctrl+c ping client now breaks the test loop and prints the stats before exiting.